### PR TITLE
Added functionality to ignore fonts

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,12 +35,14 @@ module.exports = function(options) {
     var outgoing = incoming.replace(/url(\([\s]*[^;,}]*[\s]*\))/g, function (str, dirtyUrl) {
       var url = dirtyUrl.replace(/^\(/g,'').replace(/\)$/g,'').replace(/'|"/g, '').trim();
       var replaceWithStr = null;
+	  var isFont = url.indexOf(".eot") > -1 || url.indexOf(".woff") > -1 || url.indexOf(".ttf") > -1 || url.indexOf(".otf") > -1;
       if (
-        url.indexOf("base64,") > -1
+		isFont
+        || url.indexOf("base64,") > -1
         || url.indexOf("http://") > -1
         || url.indexOf("https://") > -1
       ) {
-        replaceWithStr = str; // ignoring base64 and external links
+        replaceWithStr = str; // ignoring fonts, base64 and external links
       } else {
         var imagePath = null;
         if (url.indexOf('/') === 0) { // root-relative url


### PR DESCRIPTION
The regex incorrectly match the format() part of a font url and causes gulp to crash out. This ignores URL's that might cause this issue, be better to fix the regex but that opens up other problems such as where the font URL already requires a querystring e.g. "?#iefix"